### PR TITLE
libstdc++: Fix inconsistent noexcept-specific for valarray begin/end

### DIFF
--- a/libstdc++-v3/include/bits/range_access.h
+++ b/libstdc++-v3/include/bits/range_access.h
@@ -101,10 +101,10 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
   template<typename _Tp> class valarray;
   // These overloads must be declared for cbegin and cend to use them.
-  template<typename _Tp> _Tp* begin(valarray<_Tp>&);
-  template<typename _Tp> const _Tp* begin(const valarray<_Tp>&);
-  template<typename _Tp> _Tp* end(valarray<_Tp>&);
-  template<typename _Tp> const _Tp* end(const valarray<_Tp>&);
+  template<typename _Tp> _Tp* begin(valarray<_Tp>&) noexcept;
+  template<typename _Tp> const _Tp* begin(const valarray<_Tp>&) noexcept;
+  template<typename _Tp> _Tp* end(valarray<_Tp>&) noexcept;
+  template<typename _Tp> const _Tp* end(const valarray<_Tp>&) noexcept;
 
   /**
    *  @brief  Return an iterator pointing to the first element of


### PR DESCRIPTION
These declarations should be noexcept after I added it to the definitions in <valarray>.

libstdc++-v3/ChangeLog:

	* include/bits/range_access.h (begin(valarray), end(valarray)): Add noexcept.

(cherry picked from commit 2b2d97fc545635a0f6aa9c9ee3b017394bc494bf)